### PR TITLE
Hotfix/image fill

### DIFF
--- a/src/functions/common/functions_blocks.php
+++ b/src/functions/common/functions_blocks.php
@@ -166,7 +166,7 @@ function get_block_content_image($area, $dimensions, $compression_type, $class =
   $alt = get_page_content_string($area, 'description');
   $title = get_page_content_string($area, 'title');
 
-  return get_page_content_image($area, 'image', $dimensions, $compression_type, $class);
+  return get_page_content_image($area, 'image', $dimensions, $compression_type, $class, $fill);
 }
 
 /**

--- a/src/functions/editor/functions_pages.php
+++ b/src/functions/editor/functions_pages.php
@@ -144,7 +144,7 @@ function get_page_content_wrap($area, $column = 'html', $tag = 'div', $class = n
  * @param string $fill = '255,255,255'
  * @return string
  */
-function get_page_content_image($area, $column, $dimensions, $compression, $class = null, $fill = '255,255,255')
+function get_page_content_image($area, $column, $dimensions, $compression, $class = null, $fill = '255,255,255,0')
 {
   global $page_id;
   global $revision;

--- a/src/functions/live/functions_pages.php
+++ b/src/functions/live/functions_pages.php
@@ -79,7 +79,7 @@ function get_page_content_wrap($area, $column = 'html', $tag = 'div', $class = n
  * @param string $fill = '255,255,255'
  * @return string
  */
-function get_page_content_image($area, $column, $dimensions, $compression, $class = null, $fill = '255,255,255')
+function get_page_content_image($area, $column, $dimensions, $compression, $class = null, $fill = '255,255,255,0')
 {
   if ($compression == 'o') {
     $dimensions = '';


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/apility/netflex-sdk/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes an issue where the 'fill' property did not get passed on to get_page_content_image when calling get_block_content_image.


* **What is the current behavior?** (You can also link to an open issue here)
Fill is ignored, and the default value of '255,255,255' is used.


* **What is the new behavior (if this is a feature change)?**
Fill is passed on, and the default fill is set to '255,255,255,0'


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
It could change the behavior on some sites.


* **Other information**:
