### PR TITLE
Fix get_customer_data

### DIFF
--- a/src/functions/common/functions_customers.php
+++ b/src/functions/common/functions_customers.php
@@ -9,7 +9,6 @@
  */
 function get_customer_data($username, $data = null)
 {
-  $username = convert_to_safe_string($username, 'text');
   $data = convert_to_safe_string($data, 'str');
 
   try {


### PR DESCRIPTION
## What is wrong
get_customer_data takes a username as argument, which is run through the `convert_to_safe_string` function, which
seemingly only adds a few quotes to the end of the string.

This string is injected in to the URL of the call that resolves the data. This call fails because it does not expect
the field to be quoted.

## What is the fix?
Dont use convert_to_safe_string

## How does it work
It actually resvoles stuff now
