### PR TITLE
Implement revision handling for models

### DIFF
--- a/src/model/Structure.php
+++ b/src/model/Structure.php
@@ -279,6 +279,8 @@ abstract class Structure implements ArrayAccess, Serializable, JsonSerializable
 
   public static function find($id)
   {
+    global $entry_override;
+    global $revision_override;
 
     if (is_null($id)) {
       return null;
@@ -301,19 +303,19 @@ abstract class Structure implements ArrayAccess, Serializable, JsonSerializable
       $data = null;
       $cacheKey = 'entry/' . $id;
 
-      if (NF::$cache->has($cacheKey)) {
+      if (NF::$cache->has($cacheKey) && !isset($entry_override)) {
         $data = NF::$cache->fetch($cacheKey);
       }
 
       if (!$data) {
-        $response = NF::$capi->get('builder/structures/entry/' . $id);
+        $response = NF::$capi->get('builder/structures/entry/' . $id . (isset($entry_override) ? "/revision/$revision_override" : ""));
         $data = json_decode($response->getBody(), true);
 
         if (!$data || $data['directory_id'] != $structureId) {
           $data = null;
         }
 
-        if ($data) {
+        if ($data && !isset($entry_override)) {
           NF::$cache->save($cacheKey, $data);
         }
       }

--- a/src/pagefinder/preview_entry.php
+++ b/src/pagefinder/preview_entry.php
@@ -8,6 +8,7 @@ global $edit_tools;
 global $_mode;
 global $_domain;
 global $url_asset;
+global $entry_override;
 global $revision_override;
 global $previewmode;
 
@@ -24,8 +25,8 @@ $structure = json_decode(NF::$capi->get('builder/structures/' . $entry['director
 
 NF::$site->loadPage($structure['canonical_page_id'], NULL);
 
-$entry = json_decode(NF::$capi->get('builder/structures/entry/' . $entry_id . '/revision/' . $entry_revision)->getBody(), true);;
 
+$entry = json_decode(NF::$capi->get('builder/structures/entry/' . $entry_id . '/revision/' . $entry_revision)->getBody(), true);
 
 $page_id = $structure['canonical_page_id'];
 
@@ -62,6 +63,7 @@ switch (trim($structure['url_scheme'], '/')) {
     die('Invalid url_scheme');
 }
 
+$entry_override = $payload->entry_id;
 $revision_override = $entry_revision;
 
 NF::$site->loadGlobals();


### PR DESCRIPTION
This PR implements support live previewing for Model data.

We made code for this earlier, but when edit mode was reimplemented part was seemingly removed or forgotten. This PR (re)introduces code that loads a specific revision of a single entry (the one being edited).

When said entry is loaded, we skip both loading and storing cache