### PR TITLE
Entry retrieval issues

### DIFF
--- a/src/functions/common/functions_directories.php
+++ b/src/functions/common/functions_directories.php
@@ -8,10 +8,11 @@
  */
 function get_directory_entry($id)
 {
+  global $entry_override;
   global $revision_override;
 
   $id = convert_to_safe_string($id, 'int');
-  $entrydata = $revision_override ? null : NF::$cache->fetch("entry/$id");
+  $entrydata = (isset($entry_override) && $entry_override == $id && isset($revision_override)) ? null : NF::$cache->fetch("entry/$id");
 
   if ($entrydata == null) {
     $url = 'builder/structures/entry/' . $id;
@@ -56,7 +57,7 @@ function get_directory_entry($id)
     NF::debug($entrydata, 'entry ' . $id . ' from memory');
   }
 
-  if ($entrydata && ($entrydata['published']) || $revision_override) {
+  if ($entrydata && ($entrydata['published']) || ($entry_override == $id && isset($revision_override))) {
     return $entrydata;
   }
 }

--- a/src/functions/common/functions_directories.php
+++ b/src/functions/common/functions_directories.php
@@ -4,7 +4,7 @@
  * Get entry data
  *
  * @param int $id
- * @return array
+ * @return array|null
  */
 function get_directory_entry($id)
 {
@@ -54,7 +54,9 @@ function get_directory_entry($id)
     NF::debug($entrydata, 'entry ' . $id . ' from memory');
   }
 
-  return $entrydata;
+  if ($entrydata && ($entrydata['published']) || $revision_override) {
+    return $entrydata;
+  }
 }
 
 /**
@@ -235,8 +237,10 @@ function get_entry_content_list($entry_id, $area, $content_type)
   $data = $entry[$area];
   $contentList = [];
 
-  foreach ($data as $item) {
-    $contentList[] = $item[$content_type];
+  if ($entry) {
+    foreach ($data as $item) {
+      $contentList[] = $item[$content_type];
+    }
   }
 
   return $contentList;

--- a/src/functions/common/functions_directories.php
+++ b/src/functions/common/functions_directories.php
@@ -15,7 +15,9 @@ function get_directory_entry($id)
 
   if ($entrydata == null) {
     $url = 'builder/structures/entry/' . $id;
-    $url .= $revision_override ? ('/revision/' . $revision_override) : '';
+    if (isset($entry_override) && $entry_override == $id && isset($revision_override)) {
+      $url .= '/revision/' . $revision_override;
+    }
 
     try {
       $entrydata = json_decode(NF::$capi->get($url)->getBody(), true);

--- a/src/model/Structure.php
+++ b/src/model/Structure.php
@@ -308,7 +308,11 @@ abstract class Structure implements ArrayAccess, Serializable, JsonSerializable
       }
 
       if (!$data) {
-        $response = NF::$capi->get('builder/structures/entry/' . $id . (isset($entry_override) ? "/revision/$revision_override" : ""));
+        $url = 'builder/structures/entry/' . $id;
+        if (isset($entry_override) && $entry_override == $id && isset($revision_override)) {
+          $url .= '/revision/' . $revision_override;
+        }
+        $response = NF::$capi->get($url);
         $data = json_decode($response->getBody(), true);
 
         if (!$data || $data['directory_id'] != $structureId) {

--- a/tests/TestSuites/Common/function_directories/__snapshots__/Common_GetDirectoryEntryTest__testCanOverrideRevision__2.json
+++ b/tests/TestSuites/Common/function_directories/__snapshots__/Common_GetDirectoryEntryTest__testCanOverrideRevision__2.json
@@ -1,0 +1,7 @@
+{
+    "id": 10099,
+    "name": "Test 3",
+    "url": "test-3\/",
+    "revision": 10003,
+    "published": false
+}

--- a/tests/TestSuites/Common/function_directories/__snapshots__/Common_GetDirectoryEntryTest__testCanOverrideRevision__3.json
+++ b/tests/TestSuites/Common/function_directories/__snapshots__/Common_GetDirectoryEntryTest__testCanOverrideRevision__3.json
@@ -1,0 +1,7 @@
+{
+    "id": 10098,
+    "name": "Test 3",
+    "url": "test-3\/",
+    "revision": 10002,
+    "published": true
+}

--- a/tests/TestSuites/Common/function_directories/__snapshots__/Common_GetEntryTest__testCanOverrideRevision__2.json
+++ b/tests/TestSuites/Common/function_directories/__snapshots__/Common_GetEntryTest__testCanOverrideRevision__2.json
@@ -1,0 +1,7 @@
+{
+    "id": 10099,
+    "name": "Test 3",
+    "url": "test-3\/",
+    "revision": 10003,
+    "published": false
+}

--- a/tests/TestSuites/Common/function_directories/__snapshots__/Common_GetEntryTest__testCanOverrideRevision__3.json
+++ b/tests/TestSuites/Common/function_directories/__snapshots__/Common_GetEntryTest__testCanOverrideRevision__3.json
@@ -1,0 +1,7 @@
+{
+    "id": 10098,
+    "name": "Test 3",
+    "url": "test-3\/",
+    "revision": 10002,
+    "published": true
+}

--- a/tests/TestSuites/Common/function_directories/common.get_directory_entry.test.php
+++ b/tests/TestSuites/Common/function_directories/common.get_directory_entry.test.php
@@ -52,6 +52,7 @@ final class Common_GetDirectoryEntryTest extends TestCase
   public function testCanOverrideRevision (): void
   {
     global $revision_override;
+    global $entry_override;
 
     NF::$cache->mockItem('entry/10003', [
       'id' => 10003,
@@ -69,9 +70,32 @@ final class Common_GetDirectoryEntryTest extends TestCase
       'published' => false
     ])));
 
+    $entry_override = 10003;
     $revision_override = 10001;
 
     $this->assertMatchesJsonSnapshot(get_directory_entry(10003));
+
+    NF::$cache->mockItem('entry/10098', [
+      'id' => 10098,
+      'name' => 'Test 3',
+      'url' => 'test-3/',
+      'revision' => 10002,
+      'published' => true
+    ]);
+
+    NF::$capi->mockResponse(new Response(200, ['Content-Type' => 'application/json'], json_encode([
+      'id' => 10099,
+      'name' => 'Test 3',
+      'url' => 'test-3/',
+      'revision' => 10003,
+      'published' => false
+    ])));
+
+    $entry_override = 10099;
+    $revision_override = 10003;
+
+    $this->assertMatchesJsonSnapshot(get_directory_entry(10099));
+    $this->assertMatchesJsonSnapshot(get_directory_entry(10098));
   }
 
   public function testRespectsPublishedAttribute (): void

--- a/tests/TestSuites/Common/function_directories/common.get_directory_entry.test.php
+++ b/tests/TestSuites/Common/function_directories/common.get_directory_entry.test.php
@@ -73,5 +73,18 @@ final class Common_GetDirectoryEntryTest extends TestCase
 
     $this->assertMatchesJsonSnapshot(get_directory_entry(10003));
   }
+
+  public function testRespectsPublishedAttribute (): void
+  {
+    NF::$capi->mockResponse(new Response(200, ['Content-Type' => 'application/json'], json_encode([
+      'id' => 10004,
+      'name' => 'Test 4',
+      'url' => 'test-4/',
+      'revision' => 10000,
+      'published' => false
+    ])));
+
+    $this->assertNull(get_directory_entry(10004));
+  }
 }
 

--- a/tests/TestSuites/Common/function_directories/common.get_entry.test.php
+++ b/tests/TestSuites/Common/function_directories/common.get_entry.test.php
@@ -52,6 +52,7 @@ final class Common_GetEntryTest extends TestCase
   public function testCanOverrideRevision (): void
   {
     global $revision_override;
+    global $entry_override;
 
     NF::$cache->mockItem('entry/10003', [
       'id' => 10003,
@@ -69,9 +70,45 @@ final class Common_GetEntryTest extends TestCase
       'published' => false
     ])));
 
+    $entry_override = 10003;
     $revision_override = 10001;
 
     $this->assertMatchesJsonSnapshot(get_entry(10003));
+
+    NF::$cache->mockItem('entry/10098', [
+      'id' => 10098,
+      'name' => 'Test 3',
+      'url' => 'test-3/',
+      'revision' => 10002,
+      'published' => true
+    ]);
+
+    NF::$capi->mockResponse(new Response(200, ['Content-Type' => 'application/json'], json_encode([
+      'id' => 10099,
+      'name' => 'Test 3',
+      'url' => 'test-3/',
+      'revision' => 10003,
+      'published' => false
+    ])));
+
+    $entry_override = 10099;
+    $revision_override = 10003;
+
+    $this->assertMatchesJsonSnapshot(get_entry(10099));
+    $this->assertMatchesJsonSnapshot(get_entry(10098));
+  }
+
+  public function testRespectsPublishedAttribute (): void
+  {
+    NF::$capi->mockResponse(new Response(200, ['Content-Type' => 'application/json'], json_encode([
+      'id' => 10004,
+      'name' => 'Test 4',
+      'url' => 'test-4/',
+      'revision' => 10000,
+      'published' => false
+    ])));
+
+    $this->assertNull(get_entry(10004));
   }
 }
 

--- a/tests/TestSuites/Common/function_directories/common.get_entry_content_list.test.php
+++ b/tests/TestSuites/Common/function_directories/common.get_entry_content_list.test.php
@@ -19,6 +19,7 @@ final class Common_GetEntryContentListTest extends TestCase
   public function testGetEntryContentList (): void
   {
     NF::$cache->mockItem('entry/10000', [
+      'published' => true,
       'gallery' => [
         ['image' => 'image-1.png'],
         ['image' => 'image-2.png'],

--- a/tests/TestSuites/Common/function_directories/common.get_entry_variants.test.php
+++ b/tests/TestSuites/Common/function_directories/common.get_entry_variants.test.php
@@ -19,6 +19,7 @@ final class Common_GetEntryVariants extends TestCase
   public function testGetEntryVariants (): void
   {
     NF::$cache->mockItem('entry/10000', [
+      'published' => true,
       'variants' => [
         ['variant1'],
         ['variant2']


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/apility/netflex-sdk/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
* Fixes a bug where in entry preview mode (fixes #40)
* Fixes a bug when retrieving unpublished entries (fixes #41)

* **What is the new behavior (if this is a feature change)?**
* In entry preview mode, the overridden revision will now only apply to the currently previewed entry.
* When retrieving a entry that is not published, it now returns `NULL` (unless in entry preview mode)
