### PR TITLE
Only load recaptcha when it is actually used

### DIFF
--- a/src/Netflex/Site/Support/CaptchaV2.php
+++ b/src/Netflex/Site/Support/CaptchaV2.php
@@ -37,7 +37,7 @@ class CaptchaV2
    * Returns the script tag that has to be included for the captcha to work
    * @return string Script tag
    */
-  public static function scriptTag($override=false)
+  public static function scriptTag($override=NULL)
   {
     return ($override ?? static::$printTag) ? '<script src="https://www.google.com/recaptcha/api.js"></script>' : '';
   }

--- a/src/Netflex/Site/Support/CaptchaV2.php
+++ b/src/Netflex/Site/Support/CaptchaV2.php
@@ -13,7 +13,7 @@ use Netflex\Site\Support\ConfigurationMissingException;
  */
 class CaptchaV2
 {
-
+  private static $printTag = false;
   /**
    * Gets the contents of the captcha config
    * @return Object Captcha Config
@@ -39,7 +39,7 @@ class CaptchaV2
    */
   public static function scriptTag()
   {
-    return '<script src="https://www.google.com/recaptcha/api.js"></script>';
+    return static::$printTag ? '<script src="https://www.google.com/recaptcha/api.js"></script>' : '';
   }
 
   /**
@@ -48,6 +48,7 @@ class CaptchaV2
    */
   public static function checkBox()
   {
+    static::$printTag = true;
     return '<div class="g-recaptcha" data-sitekey="' . static::getCredentials()->siteKey . '"></div>';
   }
 

--- a/src/Netflex/Site/Support/CaptchaV2.php
+++ b/src/Netflex/Site/Support/CaptchaV2.php
@@ -37,9 +37,9 @@ class CaptchaV2
    * Returns the script tag that has to be included for the captcha to work
    * @return string Script tag
    */
-  public static function scriptTag()
+  public static function scriptTag($override=false)
   {
-    return static::$printTag ? '<script src="https://www.google.com/recaptcha/api.js"></script>' : '';
+    return ($override ?? static::$printTag) ? '<script src="https://www.google.com/recaptcha/api.js"></script>' : '';
   }
 
   /**


### PR DESCRIPTION
The current Recaptcha implementation suggests placing the script tag in a footer or similar.
This forces the recaptcha code to be loaded on all requests, even the ones without a form. This negatively impacts users privacy.

This code adds a check for wether or not the Checkbox code has been called prior to script tag. Effectively only requiring the captcha code on pages with a captcha box.

