### PR TITLE
Refactor Console handler

### DIFF
--- a/src/NF.php
+++ b/src/NF.php
@@ -9,7 +9,7 @@ use Netflex\Site\Util;
 use Netflex\Site\Commerce;
 use Netflex\Site\Search;
 use Netflex\Site\JWT;
-use PhpConsole\Handler;
+use Netflex\Site\Console;
 
 class NF
 {
@@ -35,7 +35,10 @@ class NF
   public static $config;
   /** @var array[string]string */
   public static $routes;
-  /** @var Handler */
+  /**
+   * @deprecated 1.0.11
+   * @var Console
+   * */
   public static $console;
   /** @var string */
   public static $sitename;
@@ -83,7 +86,7 @@ class NF
       self::clearCache();
     }
 
-    self::$console = self::startPhpConsole();
+    self::$console = Console::getInstance();
     self::$site = new Site();
 
     // Datastore for Netflex
@@ -165,17 +168,13 @@ class NF
   /**
    * Instantiates a PHPConsole session
    *
-   * @return PhpConsole
+   * @deprecated 1.0.11
+   * @return Console
    */
   public static function startPhpConsole()
   {
-    $console = null;
-    if (getenv('ENV') !== 'master') {
-      $console = Handler::getInstance();
-      $console->getConnector()->setSourcesBasePath($_SERVER['DOCUMENT_ROOT']);
-      $console->start();
-    }
-    return $console;
+    trigger_error('NF::startPhpConsole is deprecated', E_USER_DEPRECATED);
+    return new Console();
   }
 
   /**
@@ -186,9 +185,8 @@ class NF
    */
   public static function debug($text, $label = null)
   {
-    if (self::$console) {
-      self::$console->debug($text, $label);
-    }
+    $console = Console::getInstance();
+    $console->log($text, $label);
   }
 
   /**

--- a/src/Netflex/Site/Console.php
+++ b/src/Netflex/Site/Console.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Netflex\Site;
+
+use PhpConsole\Handler;
+
+class Console {
+  /** @var Handler */
+  private $handler;
+
+  /** @var static */
+  private static $instance;
+
+  protected function __construct()
+  {
+    if (getenv('ENV') !== 'master') {
+      $this->handler = Handler::getInstance();;
+      $this->handler->getConnector()->setSourcesBasePath($_SERVER['DOCUMENT_ROOT']);
+      $this->handler->start();
+    }
+  }
+
+  /**
+   * Instantiates a Console instance
+   *
+   * @return Console
+   */
+  public static function getInstance () {
+    if (!self::$instance) {
+      self::$instance = new static;
+    }
+
+    return self::$instance;
+  }
+
+  /**
+   * Logs the text to console (if not in production)
+   *
+   * @param string $text
+   * @param string $labels One or more labels separated by .
+   * @return void
+   */
+  public function log ($text, $labels = null) {
+    if ($this->handler) {
+      $this->handler->debug($text, $labels);
+    }
+  }
+
+  /**
+   * @deprecated 1.0.11
+   *
+   * @param string $text
+   * @param string $label
+   * @return void
+   */
+  public function debug ($text, $label)
+  {
+    trigger_error('NF::$console->debug is deprecated', E_USER_DEPRECATED);
+    return $this->log($text, $label);
+  }
+}

--- a/tests/mocks/NF.php
+++ b/tests/mocks/NF.php
@@ -3,10 +3,8 @@
 require_once(__DIR__ . '/Cache.php');
 require_once(__DIR__ . '/Guzzle.php');
 require_once(__DIR__ . '/Site.php');
-require_once(__DIR__ . '/PHPConsole.php');
 
 NF::$capi = new MockGuzzle();
 NF::$cache = new MockCache();
 NF::$site = new MockSite();
-NF::$console = new MockPHPConsole();
 NF::$site_root = __DIR__ . '/project/';

--- a/tests/mocks/PHPConsole.php
+++ b/tests/mocks/PHPConsole.php
@@ -1,7 +1,0 @@
-<?php
-
-class MockPHPConsole {
-  public function debug (...$args) {
-    return null;
-  }
-}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](/apility/netflex-sdk/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

In this PR we have refactored the direct dependency to PHPConsole, by wrapping it up in our own Console class.

This way we can handle a few edge cases where some sites where incorrectly using the ```NF::$console``` instance directly, instead of through the ```NF::debug()``` method.
