### PR TITLE
Strips port from host strings compared to domains

### DIFF
--- a/src/pagefinder/domainrouting.php
+++ b/src/pagefinder/domainrouting.php
@@ -6,7 +6,7 @@ if (isset($_SESSION['dev_domain']) && getenv('ENV') !== 'master') {
 } else if (isset(NF::$config['domains']['dev_domain']) && getenv('ENV') !== 'master') {
   $routing_domain = NF::$config['domains']['dev_domain'];
 } else {
-  $routing_domain = convert_to_safe_string($_SERVER['HTTP_HOST'], 'str');
+  $routing_domain = explode(':', $_SERVER['HTTP_HOST'])[0];
 }
 
 NF::debug('Domain', $routing_domain);


### PR DESCRIPTION
When the router uses the domains config, it compares `$_SERVER['HTTP_HOST']` to the domains.
When a site is tried reached using a port in the url, the equality check will fail, and it will default to the default setting.
This is particularly when using `netflex-cli` to host it locally, as there is always a port in the url.