### PR TITLE
Fix loadPage caching

### DIFF
--- a/src/Netflex/Site/Cache.php
+++ b/src/Netflex/Site/Cache.php
@@ -196,9 +196,9 @@ class Cache
    * @param $ttl int Cache time to live
    * @param $callback function A function that resolves the value if it is not already cached
    */
-  public static function resolve($key, $ttl = 3600, $callback) {
-    if (self::$cache->has($key)) {
-      return self::$cache->get($key);
+  public function resolve($key, $ttl = 3600, $callback) {
+    if ($this->has($key)) {
+      return $this->get($key);
     }
 
     $ttlValue = null;
@@ -216,8 +216,8 @@ class Cache
       $response = $callback();
     }
 
-    self::$cache->set($key, $response, '_', $ttlValue ?? $ttl);
+    $this->set($key, $response, '_', $ttlValue ?? $ttl);
 
-    return self::$cache->get($key);
+    return $this->get($key);
   }
 }

--- a/src/Netflex/Site/Site.php
+++ b/src/Netflex/Site/Site.php
@@ -74,10 +74,10 @@ class Site
   public function loadPage($id, $revision) {
     global $_mode;
 
-    $this->content = NF::$cache->fetch('page/' . $id);
+    $this->content = NF::$cache->fetch("page/$id");
     if ($_mode || !$this->content) {
       $this->loadContent($id, $revision);
-      NF::$cache->save('page/$id', $this->content);
+      NF::$cache->save("page/$id", $this->content);
     }
   }
 


### PR DESCRIPTION
Old loadPage would store cache as "page/$id" (where $id would not get resolved to a value) therefore always 
storing the data in the same variable that would never be loaded again.

This fix fixes this bug