### PR TITLE
Fix cache issue

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -6,6 +6,8 @@ NF::init(getenv('SERVER_SITENAME'));
 // Set standard variables
 $current_date = date('Y-m-d H:i:s');
 $edit_tools = null;
+
+/** @type mixed */
 $url_asset = null;
 $tested_url = null;
 

--- a/src/Netflex/Site/Site.php
+++ b/src/Netflex/Site/Site.php
@@ -75,7 +75,10 @@ class Site
     global $_mode;
 
     $this->content = NF::$cache->fetch("page/$id");
-    if ($_mode || !$this->content) {
+    if ($_mode) {
+      $this->content = [];
+      $this>-loadContent($id, $revision);
+    } else if (!$this->content) {
       $this->loadContent($id, $revision);
       NF::$cache->save("page/$id", $this->content);
     }
@@ -85,7 +88,6 @@ class Site
   public function loadContent($id, $revision) {
     try {
       $contentItems = json_decode(NF::$capi->get('builder/pages/' . $id . '/content' . ($revision ? ('/' . $revision) : ''))->getBody(), true);
-
       foreach ($contentItems as $item) {
         if ($item['published'] === '1') {
           if (isset($this->content[$item['area']])) {

--- a/src/functions/common/functions_pages.php
+++ b/src/functions/common/functions_pages.php
@@ -140,8 +140,6 @@ function get_page_name($id)
  */
 function get_page_data($id, $field = null)
 {
-  global $site;
-
   if ($field) {
     return NF::$site->pages[$id][$field];
   }

--- a/src/model/Structure.php
+++ b/src/model/Structure.php
@@ -95,7 +95,6 @@ abstract class Structure implements ArrayAccess, Serializable, JsonSerializable
         NF::$capi->put('builder/structures/entry/' . $this->id, $payload);
         static::performHookOn($this, 'updated');
       } else {
-
         static::performHookOn($this, 'creating');
         $response = NF::$capi->post('builder/structures/' . $this->directory . '/entry', $payload);
         static::performHookOn($this, 'created');


### PR DESCRIPTION
Fixing loadPage caching broke edit mode. This is why.

loadContent appends data to an array that was presumed to be empty on
load. A faulty if statement allowed content to be fetched from cache but
then still trigger a loadContent in edit mode. This would convert
expected associative arrays into an array of associative arrays.

then most functions utilizing content would just not find anything in
the expected keys, cause keys were now numeric and not string based keys
as expected and therefore just returned null. PHP is great is it not?

This is a very similar issue to other missing content bugs we have encountered in relation to the
way arrays are stored in the database and is "expanded" in the sdk.

These kinds of errors could be mitigated if we convert the internals for object storage from
objects to arrays and just convert to arrays near the edges.
