### PR TITLE
Makes ElasticSearch execute method public

### DIFF
--- a/src/Netflex/Site/ElasticSearch.php
+++ b/src/Netflex/Site/ElasticSearch.php
@@ -194,7 +194,7 @@ class ElasticSearch
    * @throws Exception
    * @return void
    */
-  private function execute()
+  public function execute()
   {
     if (!get_setting('use_elasticsearch')) {
       throw new Exception('ElasticSearch is not enabled for this site');


### PR DESCRIPTION
Using pagination was very impractical, because there is was way, using the chaining api, to do a search, and get the raw results.
You had to trigger `fetch`, off chain, and then use `getRawResults` to get the raw data.