### PR TITLE
Makes Netflex\Site\execute return $this

### DIFF
--- a/src/Netflex/Site/ElasticSearch.php
+++ b/src/Netflex/Site/ElasticSearch.php
@@ -192,7 +192,7 @@ class ElasticSearch
    * Performs the actual search with the built query
    *
    * @throws Exception
-   * @return void
+   * @return static
    */
   public function execute()
   {
@@ -220,6 +220,8 @@ class ElasticSearch
       NF::debug($ex, 'ElasticSearch');
       throw new Exception(json_encode($this->query));
     }
+    
+    return $this;
   }
 
   /**


### PR DESCRIPTION
This is to allow chaining after calls to `execute`.

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](/apility/netflex-sdk/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
