### PR TITLE
Set domain correctly when viewing extensoins

### DIFF
--- a/src/pagefinder/view_extension.php
+++ b/src/pagefinder/view_extension.php
@@ -1,4 +1,7 @@
 <?php
+global $_domain;
+
+$_domain = $payload->domain;
 
 if (isset($payload->get)) {
   foreach ($payload->get as $key => $value) {


### PR DESCRIPTION
Extensions does not get asset urls prefixed with the correct domain.

This is because it is never set for extensions.

This PR sets the domain