### PR TITLE
Add @apility/netflex-api dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,8 @@
     "phpfastcache/phpfastcache": "^7.0",
     "php-console/php-console": "^3.1",
     "ivopetkov/html5-dom-document-php": "^2.0",
-    "tightenco/collect": "^5.8"
+    "tightenco/collect": "^5.8",
+    "apility/netflex-api": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,46 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9fd1d7216836c9e36a4a299bcc24062",
+    "content-hash": "ee7dc4aa89ec41c279abe46ff3ddb874",
     "packages": [
+        {
+            "name": "apility/netflex-api",
+            "version": "v1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/apility/netflex-api.git",
+                "reference": "75ddfb16c1b666f1f4ee96c91470ad019dad0037"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/apility/netflex-api/zipball/75ddfb16c1b666f1f4ee96c91470ad019dad0037",
+                "reference": "75ddfb16c1b666f1f4ee96c91470ad019dad0037",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.3"
+            },
+            "require-dev": {
+                "vlucas/phpdotenv": "^3.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Netflex\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Thomas Alrek",
+                    "email": "thomas@apility.no"
+                }
+            ],
+            "time": "2019-10-16T10:39:00+00:00"
+        },
         {
             "name": "guzzlehttp/guzzle",
             "version": "6.3.3",
@@ -1483,8 +1521,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
@@ -1625,8 +1663,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Utility class for timing",
@@ -1755,8 +1793,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "The PHP Unit Testing framework.",
@@ -2332,8 +2370,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Collection of value objects that represent the types of the PHP type system",
@@ -2415,9 +2453,9 @@
             "authors": [
                 {
                     "name": "Sebastian De Deyne",
-                    "role": "Developer",
                     "email": "sebastian@spatie.be",
-                    "homepage": "https://spatie.be"
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
                 }
             ],
             "description": "Snapshot testing with PHPUnit",

--- a/src/NF.php
+++ b/src/NF.php
@@ -10,6 +10,7 @@ use Netflex\Site\Console;
 use Netflex\Site\Security;
 use Netflex\Site\Commerce;
 use Netflex\Site\ElasticSearch;
+use Netflex\API;
 
 class NF
 {
@@ -194,10 +195,65 @@ class NF
    */
   private static function initGuzzle($config)
   {
+    API::setCredentials(
+      $config['api']['pubkey'],
+      $config['api']['privkey']
+    );
+
     return new Client([
       'base_uri' => 'https://api.netflexapp.com/v1/',
       'auth'    => [$config['api']['pubkey'], $config['api']['privkey']]
     ]);
+  }
+
+  /**
+   * Performs API request with HTTP GET method and returns the response
+   *
+   * @param string $url Relative to the /v1/ root of the API
+   * @param bool $assoc = false Determines if the response should be parsed as associative array or object
+   * @return object|array
+   */
+  public static function get ($url, $assoc = false) {
+    return API::getClient()
+      ->get($url, $assoc);
+  }
+
+  /**
+   * Performs API request with HTTP PUT method and returns the response
+   *
+   * @param string $url Relative to the /v1/ root of the API
+   * @param array $payload = []
+   * @param bool $assoc = false Determines if the response should be parsed as associative array or object
+   * @return object|array
+   */
+  public static function put ($url, $payload = [], $assoc = false) {
+    return API::getClient()
+      ->put($url, $payload, $assoc);
+  }
+
+  /**
+   * Performs API request with HTTP POST method and returns the response
+   *
+   * @param string $url Relative to the /v1/ root of the API
+   * @param array $payload = []
+   * @param bool $assoc = false Determines if the response should be parsed as associative array or object
+   * @return object|array|string
+   */
+  public static function post ($url, $payload = [], $assoc = false) {
+    return API::getClient()
+      ->post($url, $payload, $assoc);
+  }
+
+  /**
+   * Performs API request with HTTP DELETE method and returns the response
+   *
+   * @param string $url Relative to the /v1/ root of the API
+   * @param bool $assoc = false Determines if the response should be parsed as associative array or object
+   * @return object|array|string
+   */
+  public static function delete ($url, $assoc = false) {
+    return API::getClient()
+      ->delete($url, $assoc);
   }
 
   /**


### PR DESCRIPTION
This feature adds @apility/netflex-api as a dependency, and adds the following new wrapper methods to the NF class.

```NF::get($url, $assoc = true)```
```NF::put($url, $payload = [], $assoc = true)```
```NF::post($url, $payload = [], $assoc = true)```
```NF::delete($url, $assoc = true)```

These methods are wrappers for the internals of Netflex\API

In the framework bootstrap, we also initialize the Netflex\API with credentials.
This will let us create standalone packages for Netflex features that also works seamless with this framework.