### PR TITLE
Adds creation of nonexistent labels

### DIFF
--- a/src/functions/common/functions_system.php
+++ b/src/functions/common/functions_system.php
@@ -153,11 +153,10 @@ function calculateMac($msg, $K)
  *
  * @param string $label
  * @param string $lang = null
- * @return void
+ * @return string
  */
 function get_label($label, $lang = null)
 {
-  global $labels;
   global $page;
 
   $base64label = base64_encode($label);
@@ -169,9 +168,20 @@ function get_label($label, $lang = null)
   if ($label != null && $lang != null) {
     if (isset(NF::$site->labels[$base64label][$lang])) {
       return NF::$site->labels[$base64label][$lang];
-    }
+    } else {
+      try {
+        NF::$capi->post('foundation/labels', ['json' => [
+          'label' => $base64label
+        ]]);
+      } catch (Exception $e) {} finally {
+        NF::$site->loadLabels();
+        NF::$cache->save('labels', NF::$site->labels, 3600);
+      }
 
-    return $label;
+      if (isset(NF::$site->labels[$base64label][$lang])) {
+        return NF::$site->labels[$base64label][$lang];
+      }
+    }
   }
 
   return $label;

--- a/tests/mocks/Site.php
+++ b/tests/mocks/Site.php
@@ -39,4 +39,8 @@ class MockSite {
   public function mockTemplate () {
 
   }
+
+  public function loadLabels () {
+    // This function needs to exist for the test not to fail. We do not actually load labels from the API when running the tests, so this function does nothing.
+  }
 }


### PR DESCRIPTION
## This PR adds label creation when they don't exist.

**Do NOT merge this before [corresponding changes in the content api](https://github.com/apility/Content-API-PHP/pull/300) have been completely merged into master.**

##### Shortcommings of this PR:
* Posting the label, loading the new labels into memory, and storing it in cache takes a while, and this has to be done for every new label. If there are many, this would take a really long time. This however only happens once, and hopefully during development.
* There are direct calls to load labels and saving to cache in a `functions` function. I think this breaks with separation of concerns, and it should probably happen in `Site`. I do however not know how to best implement that.