### PR TITLE
Fix preview of revision in Structure models

### DIFF
--- a/src/model/Structure.php
+++ b/src/model/Structure.php
@@ -449,17 +449,20 @@ abstract class Structure implements ArrayAccess, Serializable, JsonSerializable
 
   public static function generateObject($data)
   {
-    global $previewmode;
-    if (isset($previewmode)) {
-      $r = new static($data);
-      if (array_key_exists('revision', $_GET) && array_key_exists('id', $_GET) && $r->id == $_GET['id']) {
-        return $r->revisions[$_GET['revision']];
-      } else {
-        return $r;
+    global $_mode;
+    global $entry_override;
+    global $revision_override;
+
+    if (isset($_mode) && $_mode) {
+      $revision = new static($data);
+      if ($revision->id == $entry_override) {
+        return $revision->revisions[$revision_override];
       }
-    } else {
-      return new static($data);
+
+      return $revision;
     }
+
+    return new static($data);
   }
 
   private static function bootUnlessBooted()


### PR DESCRIPTION
Enables preview of revision in models when editing in Netflex

The existing code used the old method of setting the `$previewmode` variable globally.

The rewritten code uses the `$_mode` global and `$entry_override` and `$revivion_override` as specified in find static function and in the entrypreview.

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](/apility/netflex-sdk/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
