### PR TITLE
Mirror content structure from loadContent

### DIFF
--- a/src/functions/common/functions_pages.php
+++ b/src/functions/common/functions_pages.php
@@ -93,32 +93,21 @@ function get_full_content_array($page_id)
     $contentItems = json_decode(NF::$capi->get('builder/pages/' . $page_id . '/content')->getBody(), true);
 
     foreach ($contentItems as $item) {
-
-      if($item['published'] === '1') {
-        
+      if ($item['published']) {
         if (isset($content[$item['area']])) {
-
           if (!isset($content[$item['area']][0])) {
-
             $existing = $content[$item['area']];
             $content[$item['area']] = null;
             $content[$item['area']] = [];
             $content[$item['area']][] = $existing;
-
           }
-
           $content[$item['area']][] = $item;
-
         } else {
-
           $content[$item['area']] = $item;
-          
         }
 
         $content['id_' . $item['id']] = $item;
-
       }
-
     }
 
     NF::$cache->save('page/' . $page_id, $content);

--- a/src/functions/common/functions_pages.php
+++ b/src/functions/common/functions_pages.php
@@ -93,25 +93,32 @@ function get_full_content_array($page_id)
     $contentItems = json_decode(NF::$capi->get('builder/pages/' . $page_id . '/content')->getBody(), true);
 
     foreach ($contentItems as $item) {
-      if (isset($content[$item['area']])) {
-        $existing = $content[$item['area']];
-        $content[$item['area']] = null;
-        $content[$item['area']] = [];
-        $content[$item['area']][] = $existing;
 
-        if (!isset($content[$item['area']][0])) {
-          $existing = $content[$item['area']];
-          $content[$item['area']] = null;
-          $content[$item['area']] = [];
-          $content[$item['area']][] = $existing;
+      if($item['published'] === '1') {
+        
+        if (isset($content[$item['area']])) {
+
+          if (!isset($content[$item['area']][0])) {
+
+            $existing = $content[$item['area']];
+            $content[$item['area']] = null;
+            $content[$item['area']] = [];
+            $content[$item['area']][] = $existing;
+
+          }
+
+          $content[$item['area']][] = $item;
+
+        } else {
+
+          $content[$item['area']] = $item;
+          
         }
 
-        $content[$item['area']][] = $item;
-      } else {
-        $content[$item['area']] = $item;
+        $content['id_' . $item['id']] = $item;
+
       }
 
-      $content['id_' . $item['id']] = $item;
     }
 
     NF::$cache->save('page/' . $page_id, $content);

--- a/tests/TestSuites/Common/function_blocks/__snapshots__/Common_DisplayPageBlocksTest__testOutputsMatchesSnapshot__1.html
+++ b/tests/TestSuites/Common/function_blocks/__snapshots__/Common_DisplayPageBlocksTest__testOutputsMatchesSnapshot__1.html
@@ -1,4 +1,3 @@
 <!DOCTYPE html>
 <html>
-<body><h1>Test component [display_page_blocks]</h1>
-<h1>Test component [display_page_blocks]</h1></body></html>
+<body><h1>Test component [display_page_blocks]</h1></body></html>

--- a/tests/TestSuites/Common/function_blocks/common.display_page_blocks.test.php
+++ b/tests/TestSuites/Common/function_blocks/common.display_page_blocks.test.php
@@ -30,7 +30,8 @@ final class Common_DisplayPageBlocksTest extends TestCase
             'sorting' => null,
             'name' => 'Test 1',
             'title' => 'nfabcdefghijklmno1',
-            'text' => 1
+            'text' => 1,
+            'published' => 1
           ],
           [
             'id' => 2,
@@ -39,7 +40,8 @@ final class Common_DisplayPageBlocksTest extends TestCase
             'sorting' => null,
             'name' => 'Test 2',
             'title' => 'nfabcdefghijklmno2',
-            'text' => 1
+            'text' => 1,
+            'published' => 1
           ]
         ]
       ))

--- a/tests/TestSuites/Common/function_blocks/common.display_page_blocks.test.php
+++ b/tests/TestSuites/Common/function_blocks/common.display_page_blocks.test.php
@@ -41,7 +41,7 @@ final class Common_DisplayPageBlocksTest extends TestCase
             'name' => 'Test 2',
             'title' => 'nfabcdefghijklmno2',
             'text' => 1,
-            'published' => 1
+            'published' => 0
           ]
         ]
       ))


### PR DESCRIPTION
After sdk has been changed to use api, tha content structure has been changed, and the function to load the full content array of a page has been forgotten. This updates mirrors the structure used in the loadContent function in Site.