### PR TITLE
Only declare get_block if it is not set already.

### DIFF
--- a/src/functions/common/functions_templates.php
+++ b/src/functions/common/functions_templates.php
@@ -17,27 +17,30 @@ function get_template_part($alias)
   NF::debug('templates/' . $templatealias . '/' . $alias, '!part');
 }
 
-/**
- * Get block template
- *
- * @param string $alias
- * @param array $vars = []
- * @return void
- */
-function get_block($alias, $vars = [])
-{
-  global $page;
-  global $url_asset;
 
-  if (is_array($vars)) {
-    extract($vars, EXTR_SKIP);
+
+if(!function_exists('get_block')) {
+  /**
+   * Get block template
+   *
+   * @param string $alias
+   * @param array $vars = []
+   * @return void
+   */
+  function get_block($alias, $vars = [])
+  {
+    global $page;
+    global $url_asset;
+
+    if (is_array($vars)) {
+      extract($vars, EXTR_SKIP);
+    }
+
+    NF::debug('blocks/' . $alias, 'block');
+    require(NF::$site_root . 'blocks/' . $alias . '.php');
+    NF::debug('blocks/' . $alias, '!block');
   }
-
-  NF::debug('blocks/' . $alias, 'block');
-  require(NF::$site_root . 'blocks/' . $alias . '.php');
-  NF::debug('blocks/' . $alias, '!block');
 }
-
 /**
  * Get content inside block
  *


### PR DESCRIPTION
The ability to overwrite this function is needed for the multisite
functionality of VossResort.

This change allows me to rewrite this function so it works differently
in a multi site environment, where the alias is dynamically resolved
to site specific templates using the same import statement.

Take for example you have two sites *resort* and *gondol*. You want to
share as many resources as possible between these sites but some blocks
can not be shared.

Instead of having to write custom logic that checks site, then imports
two different blocks depending on site. Lets say in `header.php` you
want to load two `head.php` blocks depending on which site. So they
get their own titles and\or javascript etc.

One could do it this way
```php

<? someCodeThatChecksIfIsVossResort() {
	get_block("header_vossresort");
} else {
	get_block("header_vossgondol");
}
} ?>
```

But with this change I can rewrite get_block to act like this instead:

```php
<? get_block("head"); ?>
```

This works by having a `head.vossresort.php` and a `head.vossgondol.php`.
And rewriting get_block to figure out which site it is on, then looking
for a `*.sitename.php` file, loading that if it is present. Then falling
back on default behaviour if a site specific file is not present.
All of which clears up the templates quite well.

I was able to do this for templates and components without change to
the existing SDK by hooking into and changing the `Site` class instance.

But block loading requires me to overwrite the get_block function. So
this change is necessary for that to be achieved.